### PR TITLE
Fix use-after-free in PeriodicReport destructor

### DIFF
--- a/src/report/periodicReport.cxx
+++ b/src/report/periodicReport.cxx
@@ -11,6 +11,7 @@ PeriodicReport::PeriodicReport(const std::string& name,
 
 PeriodicReport::~PeriodicReport()
 {
+    m_timer.cancel();
 }
 
 void PeriodicReport::start()


### PR DESCRIPTION
The `PeriodicReport` destructor was empty, so if a report was destroyed while its `boost::asio::deadline_timer` had a pending callback, `save_task` would fire and write through a dangling `this`, a use-after-free. Added `m_timer.cancel()` to the destructor. `save_task` already checks for `operation_aborted` and returns early, so nothing else is needed.

Worth confirming under ASan or valgrind that destroying a report with a pending timer no longer touches freed memory, and that normal saves still write while the report is alive.
