### PR TITLE
Make highscore updates atomic via a Lua compare-and-set

### DIFF
--- a/build/entrypoint_test.sh
+++ b/build/entrypoint_test.sh
@@ -9,6 +9,7 @@ if [ "$1" == "all" ]; then
     python test_av_mgr.py
     python test_collectors.py
     python test_rpc.py
+    python test_atomic_highscore.py
 else
     python test_$1.py $2
 fi

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -40,7 +40,8 @@ class Database {
                                             std::unordered_map<doid_t, long>& entries) = 0;
         virtual void set_highscore_entry(const std::string& collection,
                                          doid_t key,
-                                         long value) = 0;
+                                         long value,
+                                         bool reversed) = 0;
 };
 
 Database* get_dummy_db();

--- a/src/database/dummyDatabase.cxx
+++ b/src/database/dummyDatabase.cxx
@@ -69,12 +69,14 @@ class DummyDatabase : public Database {
 
         virtual void set_highscore_entry(const std::string& collection,
                                          doid_t key,
-                                         long value)
+                                         long value,
+                                         bool reversed)
         {
             std::cout << "DummyDatabase::set_highscore_entry" << std::endl;
             std::cout << "    collection: " << collection << std::endl;
             std::cout << "    key: " << key << std::endl;
             std::cout << "    value: " << value << std::endl;
+            std::cout << "    reversed: " << reversed << std::endl;
         }
 };
 

--- a/src/database/redisDatabase.cxx
+++ b/src/database/redisDatabase.cxx
@@ -242,13 +242,30 @@ class RedisDatabase : public Database {
 
         virtual void set_highscore_entry(const std::string& collection,
                                          doid_t key,
-                                         long value)
+                                         long value,
+                                         bool reversed)
         {
+            // Atomic compare-and-set: only writes if the new value beats the
+            // current one (higher for normal, lower for reversed). Without this,
+            // two concurrent updates can read the same current value and the
+            // later write overwrites the better one.
+            static const std::string script =
+                "local cur = redis.call('ZSCORE', KEYS[1], ARGV[1])\n"
+                "local val = tonumber(ARGV[2])\n"
+                "if cur == false or (ARGV[3] == '1' and val < tonumber(cur)) "
+                "or (ARGV[3] == '0' and val > tonumber(cur)) then\n"
+                "    redis.call('ZADD', KEYS[1], val, ARGV[1])\n"
+                "end\n"
+                "return 1\n";
+
             dlog << "set_highscore_entry";
-            std::vector<std::string> cmd = {"ZADD",
+            std::vector<std::string> cmd = {"EVAL",
+                                            script,
+                                            "1",
                                             m_prefix + ":avatar:" + collection,
+                                            std::to_string(key),
                                             std::to_string(value),
-                                            std::to_string(key)};
+                                            reversed ? "1" : "0"};
             set_highscore_entry(cmd);
         }
 

--- a/src/report/highscoreReport.cxx
+++ b/src/report/highscoreReport.cxx
@@ -25,5 +25,5 @@ void HighscoreReport::set(doid_t key, long value)
     }
 
     m_entries[key] = value;
-    m_db->set_highscore_entry(m_name, key, value);
+    m_db->set_highscore_entry(m_name, key, value, m_reversed);
 }

--- a/test/common/unittests.py
+++ b/test/common/unittests.py
@@ -1,4 +1,4 @@
-from tlopostats import Daemon
+from common.tlopostats import Daemon
 
 import unittest
 import datetime
@@ -129,7 +129,7 @@ class StatsTest(unittest.TestCase):
     def sendEvent(self, event, doIds=[], value=0):
         data = json.dumps({'event': event, 'doIds': doIds, 'value': value})
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
-        sock.sendto(data, ('127.0.0.1', 8963))
+        sock.sendto(data.encode(), ('127.0.0.1', 8963))
         if event.startswith('AV_'):
             time.sleep(0.1)
 
@@ -141,5 +141,5 @@ class StatsTest(unittest.TestCase):
         data = json.dumps(kwargs)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('127.0.0.1', 8964))
-        sock.send(data + '\n')
+        sock.send((data + '\n').encode())
         return json.loads(sock.recv(1024))

--- a/test/test_atomic_highscore.py
+++ b/test/test_atomic_highscore.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+
+# Regression coverage for the Redis Lua compare-and-set highscore path.
+# The bug this test guards: HighscoreReport keeps a local m_entries cache,
+# but when Redis already holds a better score that the local cache doesn't
+# know about (stale daemon, fresh replica, restart-in-progress), the old
+# bare ZADD would overwrite it. The Lua script must reject the worse value
+# even when the local cache thinks the write is the first one.
+
+from common.unittests import StatsTest
+from common.tlopostats import Daemon
+
+import unittest
+
+
+class TestAtomicHighscore(StatsTest):
+    def test_lua_rejects_stale_lower_score(self):
+        d = Daemon()
+        d.start()
+
+        self.doRPC('add_highscore', name='cd_wave', event='CD_WAVE', reversed=False)
+
+        # Pre-seed Redis with a high score AFTER the daemon has loaded its
+        # in-memory cache. The daemon's m_entries is now stale and will
+        # think any incoming value is the first one for this avatar.
+        key = Daemon.DATABASE + ':avatar:cd_wave'
+        self.client.zadd(key, {'1234': 100})
+
+        # Send a worse score. Daemon's cache says "av 1234 has nothing,
+        # 50 beats nothing, write it." Without the Lua fix, the bare ZADD
+        # would overwrite 100 with 50. With the fix, the EVAL script reads
+        # ZSCORE, sees 100, and refuses the lower value.
+        self.sendEvent('CD_WAVE', [1234], 50)
+
+        self.expectHighscore('cd_wave', 1234, 100)
+
+        d.stop()
+        self.resetDatabase()
+
+    def test_lua_accepts_higher_score_when_stale(self):
+        d = Daemon()
+        d.start()
+
+        self.doRPC('add_highscore', name='cd_wave', event='CD_WAVE', reversed=False)
+
+        # Same setup as above (stale cache) but the new value DOES beat
+        # the existing one. Lua should accept the write.
+        key = Daemon.DATABASE + ':avatar:cd_wave'
+        self.client.zadd(key, {'1234': 100})
+
+        self.sendEvent('CD_WAVE', [1234], 200)
+
+        self.expectHighscore('cd_wave', 1234, 200)
+
+        d.stop()
+        self.resetDatabase()
+
+    def test_lua_rejects_stale_higher_score_for_reversed(self):
+        # Reversed leaderboard (lap-time style, lower is better).
+        d = Daemon()
+        d.start()
+
+        self.doRPC('add_highscore', name='bp_time', event='BP_TIME', reversed=True)
+
+        key = Daemon.DATABASE + ':avatar:bp_time'
+        self.client.zadd(key, {'1234': 50})
+
+        # 100 is worse than 50 in a reversed leaderboard. Lua must refuse.
+        self.sendEvent('BP_TIME', [1234], 100)
+
+        self.expectHighscore('bp_time', 1234, 50)
+
+        d.stop()
+        self.resetDatabase()
+
+    def test_lua_writes_first_entry_when_no_prior_value(self):
+        # Sanity: the script's `cur == false` branch (nil from ZSCORE) must
+        # accept the write so brand-new avatars get on the board.
+        d = Daemon()
+        d.start()
+
+        self.doRPC('add_highscore', name='cd_wave', event='CD_WAVE', reversed=False)
+
+        self.sendEvent('CD_WAVE', [9999], 42)
+
+        self.expectHighscore('cd_wave', 9999, 42)
+
+        d.stop()
+        self.resetDatabase()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #9.

`HighscoreReport::set` reads the local cache, compares, then writes `ZADD key value member`, three steps with no cross-process atomicity. Two daemon replicas (or any stale-cache path) can both read the same current score and the second `ZADD` overwrites the better one, silently losing the higher value.

Replaced the bare `ZADD` with an `EVAL` of a small Lua script that does the compare-and-set inside Redis, threading `reversed` through `Database::set_highscore_entry` so it knows which direction to compare. Lua works on Redis 2.6+ so no version bump; if we confirm 6.2+ everywhere later we can swap it for `ZADD GT/LT`. Kept the in-memory cache check as a perf optimization, correctness no longer leans on it.

Tested with `test/test_atomic_highscore.py`, which reproduces the stale-cache race (seed Redis with a high score after the daemon has loaded m_entries, then send a worse value over UDP) and asserts the script keeps the better value, plus the accept path, reversed leaderboards, and the first-write branch.
