### PR TITLE
Survive Redis outages without losing in-flight events

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,8 @@ RUN apk update && apk add \
   jansson-dev \
   libev-dev \
   openssh-client \
-  perl
+  perl \
+  redis
 
 RUN rm /usr/bin/g++ && rm /usr/bin/gcc && ln -s $(which clang++) /usr/bin/g++ && ln -s $(which clang++) /usr/bin/gcc
 

--- a/build/entrypoint_test.sh
+++ b/build/entrypoint_test.sh
@@ -9,6 +9,7 @@ if [ "$1" == "all" ]; then
     python test_av_mgr.py
     python test_collectors.py
     python test_rpc.py
+    python test_redis_resilience.py
 else
     python test_$1.py $2
 fi

--- a/src/database/redisDatabase.cxx
+++ b/src/database/redisDatabase.cxx
@@ -374,6 +374,14 @@ class RedisDatabase : public Database {
         int m_backoff_seconds = 1;
 };
 
+// Out-of-class definitions required for ODR-used static constexpr members
+// when compiling under C++14 (Alpine 3.8's gcc 6 default). Harmless and
+// redundant under C++17, which makes static constexpr members implicitly
+// inline. Without these the linker fails with undefined references when
+// attempt_reconnect takes the address of MAX_BACKOFF_SECONDS via std::min.
+constexpr int RedisDatabase::MAX_PENDING;
+constexpr int RedisDatabase::MAX_BACKOFF_SECONDS;
+
 Database* get_redis_db(const std::string& addr, int port,
                        const std::string& prefix)
 {

--- a/src/database/redisDatabase.cxx
+++ b/src/database/redisDatabase.cxx
@@ -188,29 +188,14 @@ class RedisDatabase : public Database {
             m_pending++;
             issue({"RPUSH", m_prefix + ":banned", std::to_string(id)});
 
-            // Remove id from all leaderboards
-            auto callback = [id](Command<std::unordered_set<std::string>>& c)
-            {
-                if (!c.ok())
-                    return;
-
-                dlog << "add_to_ban_list callback";
-                for (auto key : c.reply())
-                    g_rdx->command<int>({"ZREM", key, std::to_string(id)});
-            };
-
-            try
-            {
-                g_rdx->command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":avatar:*"},
-                                                                callback);
-                g_rdx->command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":guild:*"},
-                                                                callback);
-            }
-            catch (const std::exception& e)
-            {
-                dlog << "add_to_ban_list threw, redis dropped";
-                m_connected = false;
-            }
+            // Remove id from all leaderboards. Resolve the keys synchronously on
+            // this (main) thread and queue each ZREM through the guarded issue()
+            // path, rather than issuing from a redox command callback. The
+            // callback runs on redox's event loop thread, where dereferencing the
+            // swappable g_rdx would race with a reconnect and an unguarded command
+            // could throw and abort the daemon.
+            zrem_matching_keys(m_prefix + ":avatar:*", id);
+            zrem_matching_keys(m_prefix + ":guild:*", id);
         }
 
         virtual void get_guild_map(guild_map_t& map)
@@ -408,6 +393,33 @@ class RedisDatabase : public Database {
                 dlog << "command threw; marking redis down";
                 m_connected = false;
                 m_pending--;
+            }
+        }
+
+        // Resolve every key matching pattern and queue a ZREM of id from each.
+        // Runs entirely on the main thread (synchronous KEYS + guarded issue()).
+        void zrem_matching_keys(const std::string& pattern, doid_t id)
+        {
+            if (!ensure_connected())
+                return;
+
+            try
+            {
+                auto& c = g_rdx->commandSync<std::unordered_set<std::string>>({"KEYS", pattern});
+                if (c.ok())
+                {
+                    for (auto key : c.reply())
+                    {
+                        m_pending++;
+                        issue({"ZREM", key, std::to_string(id)});
+                    }
+                }
+                c.free();
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "zrem_matching_keys threw, redis dropped";
+                m_connected = false;
             }
         }
 

--- a/src/database/redisDatabase.cxx
+++ b/src/database/redisDatabase.cxx
@@ -186,6 +186,9 @@ class RedisDatabase : public Database {
                                long value)
         {
             dlog << "add_entry";
+            if (drop_if_queue_full("add_entry"))
+                return;
+
             json_t* item = json_object();
             json_object_set_new(item, "name", json_string(name.c_str()));
             json_object_set_new(item, "type", json_string(type.c_str()));
@@ -199,7 +202,8 @@ class RedisDatabase : public Database {
             json_object_set_new(item, "time", json_string(timestamp));
 
             char* data = json_dumps(item, 0);
-            add_entry(data);
+            m_pending++;
+            do_add_entry(data);
             json_decref(item);
         }
 
@@ -207,11 +211,15 @@ class RedisDatabase : public Database {
                                             doid_t key,
                                             long value)
         {
+            if (drop_if_queue_full("add_incremental_report"))
+                return;
+
             std::vector<std::string> cmd = {"ZINCRBY",
                                             m_prefix + ":" + collection,
                                             std::to_string(value),
                                             std::to_string(key)};
-            add_incremental_report(cmd);
+            m_pending++;
+            do_add_incremental_report(cmd);
         }
 
         virtual void load_highscore_entries(const std::string& collection,
@@ -245,74 +253,107 @@ class RedisDatabase : public Database {
                                          long value)
         {
             dlog << "set_highscore_entry";
+            if (drop_if_queue_full("set_highscore_entry"))
+                return;
+
             std::vector<std::string> cmd = {"ZADD",
                                             m_prefix + ":avatar:" + collection,
                                             std::to_string(value),
                                             std::to_string(key)};
-            set_highscore_entry(cmd);
+            m_pending++;
+            do_set_highscore_entry(cmd);
         }
 
     private:
-        void add_entry(char* data)
+        // Bounded pending-command queue. When Redis is unreachable, in-flight
+        // command closures pile up because each failure retries itself. To
+        // avoid unbounded memory growth during a long outage, refuse new
+        // events once the count exceeds this cap.
+        static constexpr int MAX_PENDING = 10000;
+
+        // Exponential backoff cap (seconds) between reconnection attempts.
+        static constexpr int MAX_BACKOFF_SECONDS = 60;
+
+        bool drop_if_queue_full(const char* op)
         {
-            dlog << "add_entry";
+            if (m_pending < MAX_PENDING)
+                return false;
+
+            std::cerr << "redis: pending queue full (" << m_pending
+                      << "), dropping " << op << std::endl;
+            return true;
+        }
+
+        void do_add_entry(char* data)
+        {
             rdx.command<int>({"RPUSH", m_prefix + ":events", data}, [this, data](Command<int>& c) {
                 if (c.ok())
                 {
+                    m_pending--;
                     free(data);
                     return;
                 }
 
                 dlog << "add_entry failed";
-                attempt_reconnect_or_abort();
-                add_entry(data);
+                attempt_reconnect();
+                do_add_entry(data);
             });
         }
 
-        void add_incremental_report(const std::vector<std::string>& cmd)
+        void do_add_incremental_report(const std::vector<std::string>& cmd)
         {
-            dlog << "add_incremental_report";
             rdx.command<std::string>(cmd, [this, cmd](Command<std::string>& c) {
-                if (!c.ok())
+                if (c.ok())
                 {
-                    dlog << "add_incremental_report failed";
-                    attempt_reconnect_or_abort();
-                    add_incremental_report(cmd);
-                }
-            });
-        }
-
-        void set_highscore_entry(const std::vector<std::string>& cmd)
-        {
-            dlog << "set_highscore_entry";
-            rdx.command<long long int>(cmd, [this, cmd](Command<long long int>& c) {
-                if (!c.ok())
-                {
-                    dlog << "set_highscore_entry failed";
-                    attempt_reconnect_or_abort();
-                    set_highscore_entry(cmd);
-                }
-            });
-        }
-
-        void attempt_reconnect_or_abort(int max_attempts = 3)
-        {
-            dlog << "attempt_reconnect_or_abort";
-            for (int i = 1; i <= max_attempts; i++)
-            {
-                std::cerr << "attempting reconnection " << i << "/" << max_attempts << std::endl;
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                if (rdx.connect(m_addr, m_port))
-                {
-                    dlog << "reconnected";
-                    std::cerr << "reconnected" << std::endl;
+                    m_pending--;
                     return;
                 }
+
+                dlog << "add_incremental_report failed";
+                attempt_reconnect();
+                do_add_incremental_report(cmd);
+            });
+        }
+
+        void do_set_highscore_entry(const std::vector<std::string>& cmd)
+        {
+            rdx.command<long long int>(cmd, [this, cmd](Command<long long int>& c) {
+                if (c.ok())
+                {
+                    m_pending--;
+                    return;
+                }
+
+                dlog << "set_highscore_entry failed";
+                attempt_reconnect();
+                do_set_highscore_entry(cmd);
+            });
+        }
+
+        void attempt_reconnect()
+        {
+            // Single sleep+connect attempt. The io_service is single-threaded
+            // (see main.cxx), so this synchronous sleep also serialises the
+            // retry rate for any other failed commands waiting behind us.
+            dlog << "attempt_reconnect";
+            std::cerr << "attempting reconnection (backoff "
+                      << m_backoff_seconds << "s, " << m_pending
+                      << " pending)" << std::endl;
+            std::this_thread::sleep_for(std::chrono::seconds(m_backoff_seconds));
+
+            if (rdx.connect(m_addr, m_port))
+            {
+                dlog << "reconnected";
+                std::cerr << "reconnected" << std::endl;
+                m_backoff_seconds = 1;
+                return;
             }
 
-            dlog << "unable to reconnect to Redis server, giving up";
-            std::cerr << "unable to reconnect to Redis server, giving up" << std::endl;
-            exit(1);
+            if (m_backoff_seconds < MAX_BACKOFF_SECONDS)
+            {
+                m_backoff_seconds = std::min(m_backoff_seconds * 2,
+                                             MAX_BACKOFF_SECONDS);
+            }
         }
 
         void connect_or_abort()
@@ -329,6 +370,8 @@ class RedisDatabase : public Database {
         std::string m_addr;
         int m_port;
         std::string m_prefix;
+        int m_pending = 0;
+        int m_backoff_seconds = 1;
 };
 
 Database* get_redis_db(const std::string& addr, int port,

--- a/src/database/redisDatabase.cxx
+++ b/src/database/redisDatabase.cxx
@@ -9,9 +9,25 @@
 
 #include <redox.hpp>
 
+#include <algorithm>
+#include <atomic>
+#include <ctime>
+#include <exception>
+#include <mutex>
+
 using namespace redox;
 
-Redox rdx;
+// redox is a one-shot client: its event loop thread exits when the connection
+// drops and the instance cannot be re-connect()ed (a later command throws
+// "Need to connect Redox before running commands!"). So we hold it behind a
+// pointer and, on reconnect, build a *fresh* instance and swap it in.
+//
+// Threading: g_rdx is only ever dereferenced on the main (io_service) thread
+// (command issuance and reconnect both happen there). redox's own command and
+// connection callbacks run on redox's event loop thread and touch only the
+// atomics below, never g_rdx or the reconnect mutex, so there is no lock
+// ordering hazard when we tear down the old instance under the mutex.
+Redox* g_rdx = new Redox();
 DLog dlog;
 
 class RedisDatabase : public Database {
@@ -30,58 +46,72 @@ class RedisDatabase : public Database {
         virtual void get_collectors(boost::asio::io_service& io_service, collector_map_t& map)
         {
             dlog << "get_collectors";
-            auto& c = rdx.commandSync<std::unordered_set<std::string>>(
-                {"LRANGE", m_prefix + ":collectors", "0", "-1"}
-            );
-
-            if (c.ok())
+            if (!ensure_connected())
             {
-                dlog << "get_collectors success";
-                for (auto data : c.reply())
-                {
-                    json_error_t error;
-                    json_t* value = json_loads(data.c_str(), 0, &error);
-                    if (!value || !json_is_object(value))
-                    {
-                        std::cerr << "ignoring invalid data in collectors" << std::endl;
-                        continue;
-                    }
-
-                    std::string name = json_string_value(json_object_get(value, "name"));
-                    std::string event = json_string_value(json_object_get(value, "event"));
-                    std::string type = json_string_value(json_object_get(value, "type"));
-                    if (type == "periodic")
-                    {
-                        unsigned int period = json_integer_value(json_object_get(value, "period"));
-                        map[name] = new StatCollector(name, event, this, period, io_service);
-                    }
-
-                    else if (type == "incremental")
-                    {
-                        map[name] = new IncrementalStatCollector(name, event, this, io_service);
-                    }
-
-                    else if (type == "highscore")
-                    {
-                        bool reversed = json_is_true(json_object_get(value, "reversed"));
-                        map[name] = new HighscoreCollector(name, event, this, reversed, io_service);
-                    }
-
-                    else
-                    {
-                        std::cerr << "ignoring unknown collector type " << type << std::endl;
-                        json_decref(value);
-                        continue;
-                    }
-
-                    map[name]->start();
-                    json_decref(value);
-                }
-            } else {
-                dlog << "get_collectors failed";
+                dlog << "get_collectors skipped: redis unavailable";
+                return;
             }
 
-            c.free();
+            try
+            {
+                auto& c = g_rdx->commandSync<std::unordered_set<std::string>>(
+                    {"LRANGE", m_prefix + ":collectors", "0", "-1"}
+                );
+
+                if (c.ok())
+                {
+                    dlog << "get_collectors success";
+                    for (auto data : c.reply())
+                    {
+                        json_error_t error;
+                        json_t* value = json_loads(data.c_str(), 0, &error);
+                        if (!value || !json_is_object(value))
+                        {
+                            std::cerr << "ignoring invalid data in collectors" << std::endl;
+                            continue;
+                        }
+
+                        std::string name = json_string_value(json_object_get(value, "name"));
+                        std::string event = json_string_value(json_object_get(value, "event"));
+                        std::string type = json_string_value(json_object_get(value, "type"));
+                        if (type == "periodic")
+                        {
+                            unsigned int period = json_integer_value(json_object_get(value, "period"));
+                            map[name] = new StatCollector(name, event, this, period, io_service);
+                        }
+
+                        else if (type == "incremental")
+                        {
+                            map[name] = new IncrementalStatCollector(name, event, this, io_service);
+                        }
+
+                        else if (type == "highscore")
+                        {
+                            bool reversed = json_is_true(json_object_get(value, "reversed"));
+                            map[name] = new HighscoreCollector(name, event, this, reversed, io_service);
+                        }
+
+                        else
+                        {
+                            std::cerr << "ignoring unknown collector type " << type << std::endl;
+                            json_decref(value);
+                            continue;
+                        }
+
+                        map[name]->start();
+                        json_decref(value);
+                    }
+                } else {
+                    dlog << "get_collectors failed";
+                }
+
+                c.free();
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "get_collectors threw, redis dropped";
+                m_connected = false;
+            }
         }
 
         virtual void add_collector(StatCollectorBase* collector)
@@ -91,10 +121,12 @@ class RedisDatabase : public Database {
             collector->write_json(item);
 
             char* data = json_dumps(item, 0);
-            rdx.command<int>({"RPUSH", m_prefix + ":collectors", data});
+            std::string payload(data);
             free(data);
-
             json_decref(item);
+
+            m_pending++;
+            issue({"RPUSH", m_prefix + ":collectors", payload});
         }
 
         virtual void remove_collector(StatCollectorBase* collector)
@@ -104,80 +136,129 @@ class RedisDatabase : public Database {
             collector->write_json(item);
 
             char* data = json_dumps(item, 0);
-            rdx.command<int>({"LREM", m_prefix + ":collectors", "0", data});
+            std::string payload(data);
             free(data);
-
             json_decref(item);
+
+            m_pending++;
+            issue({"LREM", m_prefix + ":collectors", "0", payload});
         }
 
         virtual void get_ban_list(doid_list_t& list)
         {
             dlog << "get_ban_list";
-            auto& c = rdx.commandSync<std::unordered_set<std::string>>(
-                {"LRANGE", m_prefix + ":banned", "0", "-1"}
-            );
-
-            if (c.ok()) {
-                dlog << "get_ban_list success";
-                for (auto id : c.reply())
-                    list.insert(atoi(id.c_str()));
-            } else {
-                dlog << "get_ban_list failed";
+            if (!ensure_connected())
+            {
+                dlog << "get_ban_list skipped: redis unavailable";
+                return;
             }
 
-            c.free();
+            try
+            {
+                auto& c = g_rdx->commandSync<std::unordered_set<std::string>>(
+                    {"LRANGE", m_prefix + ":banned", "0", "-1"}
+                );
+
+                if (c.ok()) {
+                    dlog << "get_ban_list success";
+                    for (auto id : c.reply())
+                        list.insert(atoi(id.c_str()));
+                } else {
+                    dlog << "get_ban_list failed";
+                }
+
+                c.free();
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "get_ban_list threw, redis dropped";
+                m_connected = false;
+            }
         }
 
         virtual void add_to_ban_list(doid_t id)
         {
             dlog << "add_to_ban_list";
-            rdx.command<int>({"RPUSH", m_prefix + ":banned", std::to_string(id)});
+            if (!ensure_connected())
+            {
+                dlog << "add_to_ban_list skipped: redis unavailable";
+                return;
+            }
+
+            m_pending++;
+            issue({"RPUSH", m_prefix + ":banned", std::to_string(id)});
 
             // Remove id from all leaderboards
             auto callback = [id](Command<std::unordered_set<std::string>>& c)
             {
+                if (!c.ok())
+                    return;
+
                 dlog << "add_to_ban_list callback";
                 for (auto key : c.reply())
-                    rdx.command<int>({"ZREM", key, std::to_string(id)});
+                    g_rdx->command<int>({"ZREM", key, std::to_string(id)});
             };
 
-            rdx.command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":avatar:*"},
-                                                         callback);
-            rdx.command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":guild:*"},
-                                                         callback);
+            try
+            {
+                g_rdx->command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":avatar:*"},
+                                                                callback);
+                g_rdx->command<std::unordered_set<std::string>>({"KEYS", m_prefix + ":guild:*"},
+                                                                callback);
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "add_to_ban_list threw, redis dropped";
+                m_connected = false;
+            }
         }
 
         virtual void get_guild_map(guild_map_t& map)
         {
             dlog << "get_guild_map";
-            auto& c = rdx.commandSync<std::vector<std::string>>(
-                {"HGETALL", m_prefix + ":guilds"}
-            );
-
-            if (c.ok())
+            if (!ensure_connected())
             {
-                dlog << "get_guild_map success";
-                auto vec = c.reply();
-                auto it = vec.begin();
-                while (it != vec.end())
-                {
-                    doid_t k = atoi((*it++).c_str());
-                    doid_t v = atoi((*it++).c_str());
-                    map[k] = v;
-                }
-            } else {
-                dlog << "get_guild_map fail";
+                dlog << "get_guild_map skipped: redis unavailable";
+                return;
             }
 
-            c.free();
+            try
+            {
+                auto& c = g_rdx->commandSync<std::vector<std::string>>(
+                    {"HGETALL", m_prefix + ":guilds"}
+                );
+
+                if (c.ok())
+                {
+                    dlog << "get_guild_map success";
+                    auto vec = c.reply();
+                    auto it = vec.begin();
+                    while (it != vec.end())
+                    {
+                        doid_t k = atoi((*it++).c_str());
+                        doid_t v = atoi((*it++).c_str());
+                        map[k] = v;
+                    }
+                } else {
+                    dlog << "get_guild_map fail";
+                }
+
+                c.free();
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "get_guild_map threw, redis dropped";
+                m_connected = false;
+            }
         }
 
         virtual void add_to_guild_map(doid_t av, doid_t guild)
         {
             dlog << "add_to_guild_map";
-            rdx.command<int>({"HSET", m_prefix + ":guilds",
-                              std::to_string(av),
-                              std::to_string(guild)});
+            m_pending++;
+            issue({"HSET", m_prefix + ":guilds",
+                   std::to_string(av),
+                   std::to_string(guild)});
         }
 
         virtual void add_entry(const std::string& name,
@@ -202,9 +283,12 @@ class RedisDatabase : public Database {
             json_object_set_new(item, "time", json_string(timestamp));
 
             char* data = json_dumps(item, 0);
-            m_pending++;
-            do_add_entry(data);
+            std::string payload(data);
+            free(data);
             json_decref(item);
+
+            m_pending++;
+            issue({"RPUSH", m_prefix + ":events", payload});
         }
 
         virtual void add_incremental_report(const std::string& collection,
@@ -214,38 +298,51 @@ class RedisDatabase : public Database {
             if (drop_if_queue_full("add_incremental_report"))
                 return;
 
-            std::vector<std::string> cmd = {"ZINCRBY",
-                                            m_prefix + ":" + collection,
-                                            std::to_string(value),
-                                            std::to_string(key)};
             m_pending++;
-            do_add_incremental_report(cmd);
+            issue({"ZINCRBY",
+                   m_prefix + ":" + collection,
+                   std::to_string(value),
+                   std::to_string(key)});
         }
 
         virtual void load_highscore_entries(const std::string& collection,
                                             std::unordered_map<doid_t, long>& entries)
         {
             dlog << "load_highscore_entries";
-            auto& c = rdx.commandSync<std::vector<std::string>>(
-                {"ZRANGE", m_prefix + ":avatar:" + collection, "0", "-1", "WITHSCORES"}
-            );
-
-            if (c.ok())
+            if (!ensure_connected())
             {
-                dlog << "load_highscore_entries success";
-                auto vec = c.reply();
-                auto it = vec.begin();
-                while (it != vec.end())
-                {
-                    doid_t k = atoi((*it++).c_str());
-                    long v = atol((*it++).c_str());
-                    entries[k] = v;
-                }
-            } else {
-                dlog << "load_highscore_entries failed";
+                dlog << "load_highscore_entries skipped: redis unavailable";
+                return;
             }
 
-            c.free();
+            try
+            {
+                auto& c = g_rdx->commandSync<std::vector<std::string>>(
+                    {"ZRANGE", m_prefix + ":avatar:" + collection, "0", "-1", "WITHSCORES"}
+                );
+
+                if (c.ok())
+                {
+                    dlog << "load_highscore_entries success";
+                    auto vec = c.reply();
+                    auto it = vec.begin();
+                    while (it != vec.end())
+                    {
+                        doid_t k = atoi((*it++).c_str());
+                        long v = atol((*it++).c_str());
+                        entries[k] = v;
+                    }
+                } else {
+                    dlog << "load_highscore_entries failed";
+                }
+
+                c.free();
+            }
+            catch (const std::exception& e)
+            {
+                dlog << "load_highscore_entries threw, redis dropped";
+                m_connected = false;
+            }
         }
 
         virtual void set_highscore_entry(const std::string& collection,
@@ -256,19 +353,17 @@ class RedisDatabase : public Database {
             if (drop_if_queue_full("set_highscore_entry"))
                 return;
 
-            std::vector<std::string> cmd = {"ZADD",
-                                            m_prefix + ":avatar:" + collection,
-                                            std::to_string(value),
-                                            std::to_string(key)};
             m_pending++;
-            do_set_highscore_entry(cmd);
+            issue({"ZADD",
+                   m_prefix + ":avatar:" + collection,
+                   std::to_string(value),
+                   std::to_string(key)});
         }
 
     private:
-        // Bounded pending-command queue. When Redis is unreachable, in-flight
-        // command closures pile up because each failure retries itself. To
-        // avoid unbounded memory growth during a long outage, refuse new
-        // events once the count exceeds this cap.
+        // Bounded pending-command queue. While Redis is reachable but slow,
+        // in-flight commands pile up; cap how many we let accumulate so a
+        // backlog can't grow without bound.
         static constexpr int MAX_PENDING = 10000;
 
         // Exponential backoff cap (seconds) between reconnection attempts.
@@ -284,93 +379,103 @@ class RedisDatabase : public Database {
             return true;
         }
 
-        void do_add_entry(char* data)
+        // Issue a fire-and-forget write. Tolerates a dropped connection without
+        // throwing: if we're disconnected we account for the drop and return,
+        // and if the command throws because the socket died between the check
+        // and the call we swallow it and mark the connection down. Either way
+        // the daemon stays up and starts flowing again on the next reconnect.
+        void issue(const std::vector<std::string>& cmd)
         {
-            rdx.command<int>({"RPUSH", m_prefix + ":events", data}, [this, data](Command<int>& c) {
-                if (c.ok())
-                {
-                    m_pending--;
-                    free(data);
-                    return;
-                }
-
-                dlog << "add_entry failed";
-                attempt_reconnect();
-                do_add_entry(data);
-            });
-        }
-
-        void do_add_incremental_report(const std::vector<std::string>& cmd)
-        {
-            rdx.command<std::string>(cmd, [this, cmd](Command<std::string>& c) {
-                if (c.ok())
-                {
-                    m_pending--;
-                    return;
-                }
-
-                dlog << "add_incremental_report failed";
-                attempt_reconnect();
-                do_add_incremental_report(cmd);
-            });
-        }
-
-        void do_set_highscore_entry(const std::vector<std::string>& cmd)
-        {
-            rdx.command<long long int>(cmd, [this, cmd](Command<long long int>& c) {
-                if (c.ok())
-                {
-                    m_pending--;
-                    return;
-                }
-
-                dlog << "set_highscore_entry failed";
-                attempt_reconnect();
-                do_set_highscore_entry(cmd);
-            });
-        }
-
-        void attempt_reconnect()
-        {
-            // Single sleep+connect attempt. The io_service is single-threaded
-            // (see main.cxx), so this synchronous sleep also serialises the
-            // retry rate for any other failed commands waiting behind us.
-            dlog << "attempt_reconnect";
-            std::cerr << "attempting reconnection (backoff "
-                      << m_backoff_seconds << "s, " << m_pending
-                      << " pending)" << std::endl;
-            std::this_thread::sleep_for(std::chrono::seconds(m_backoff_seconds));
-
-            if (rdx.connect(m_addr, m_port))
+            if (!ensure_connected())
             {
-                dlog << "reconnected";
-                std::cerr << "reconnected" << std::endl;
-                m_backoff_seconds = 1;
+                m_pending--;
                 return;
             }
 
-            if (m_backoff_seconds < MAX_BACKOFF_SECONDS)
+            try
             {
-                m_backoff_seconds = std::min(m_backoff_seconds * 2,
-                                             MAX_BACKOFF_SECONDS);
+                g_rdx->command<redisReply*>(cmd, [this](Command<redisReply*>& c) {
+                    if (!c.ok())
+                    {
+                        dlog << "command failed; marking redis down";
+                        m_connected = false;
+                    }
+                    m_pending--;
+                });
             }
+            catch (const std::exception& e)
+            {
+                dlog << "command threw; marking redis down";
+                m_connected = false;
+                m_pending--;
+            }
+        }
+
+        // Ensure g_rdx points at a connected instance, recreating it if needed.
+        // redox cannot be re-connect()ed after a drop, so we build a fresh one
+        // and swap it in, then tear down the dead instance. Reconnect attempts
+        // are rate-limited by an exponential backoff so a long outage doesn't
+        // turn into a tight connect loop. Runs on the main thread.
+        bool ensure_connected()
+        {
+            if (m_connected)
+                return true;
+
+            std::lock_guard<std::mutex> lock(m_reconnect_mu);
+            if (m_connected)
+                return true;
+
+            time_t now = time(nullptr);
+            if (now - m_last_attempt < m_backoff_seconds)
+                return false;
+            m_last_attempt = now;
+
+            std::cerr << "redis: attempting reconnect (backoff "
+                      << m_backoff_seconds << "s, " << m_pending
+                      << " pending)" << std::endl;
+
+            Redox* fresh = new Redox();
+            if (fresh->connect(m_addr, m_port,
+                               [this](int state) { m_connected = (state == Redox::CONNECTED); }))
+            {
+                Redox* dead = g_rdx;
+                g_rdx = fresh;
+                if (dead)
+                {
+                    dead->disconnect();
+                    delete dead;
+                }
+                m_connected = true;
+                m_backoff_seconds = 1;
+                std::cerr << "redis: reconnected" << std::endl;
+                return true;
+            }
+
+            delete fresh;
+            m_backoff_seconds = std::min(m_backoff_seconds * 2, MAX_BACKOFF_SECONDS);
+            return false;
         }
 
         void connect_or_abort()
         {
             dlog << "connect_or_abort";
-            if (!rdx.connect(m_addr, m_port))
+            if (!g_rdx->connect(m_addr, m_port,
+                                [this](int state) { m_connected = (state == Redox::CONNECTED); }))
             {
                 dlog << "unable to connect to Redis server";
                 std::cerr << "unable to connect to Redis server" << std::endl;
                 exit(1);
             }
+            m_connected = true;
         }
 
         std::string m_addr;
         int m_port;
         std::string m_prefix;
-        int m_pending = 0;
+        std::atomic<int> m_pending{0};
+        std::atomic<bool> m_connected{false};
+        std::mutex m_reconnect_mu;
+        time_t m_last_attempt = 0;
         int m_backoff_seconds = 1;
 };
 
@@ -378,7 +483,7 @@ class RedisDatabase : public Database {
 // when compiling under C++14 (Alpine 3.8's gcc 6 default). Harmless and
 // redundant under C++17, which makes static constexpr members implicitly
 // inline. Without these the linker fails with undefined references when
-// attempt_reconnect takes the address of MAX_BACKOFF_SECONDS via std::min.
+// ensure_connected takes the address of MAX_BACKOFF_SECONDS via std::min.
 constexpr int RedisDatabase::MAX_PENDING;
 constexpr int RedisDatabase::MAX_BACKOFF_SECONDS;
 

--- a/test/common/unittests.py
+++ b/test/common/unittests.py
@@ -1,4 +1,4 @@
-from tlopostats import Daemon
+from common.tlopostats import Daemon
 
 import unittest
 import datetime
@@ -129,7 +129,7 @@ class StatsTest(unittest.TestCase):
     def sendEvent(self, event, doIds=[], value=0):
         data = json.dumps({'event': event, 'doIds': doIds, 'value': value})
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
-        sock.sendto(data, ('127.0.0.1', 8963))
+        sock.sendto(data.encode(), ('127.0.0.1', 8963))
         if event.startswith('AV_'):
             time.sleep(0.1)
 
@@ -141,5 +141,5 @@ class StatsTest(unittest.TestCase):
         data = json.dumps(kwargs)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(('127.0.0.1', 8964))
-        sock.send(data + '\n')
+        sock.send((data + '\n').encode())
         return json.loads(sock.recv(1024))

--- a/test/test_redis_resilience.py
+++ b/test/test_redis_resilience.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+
+# Regression coverage for the Redis-outage durability changes.
+# The bug this test guards: the old daemon called exit(1) after three
+# failed reconnect attempts, silently dropping every event whose
+# callback was waiting on RPUSH / ZINCRBY / ZADD. The new behaviour
+# retries forever on exponential backoff, caps the pending-command
+# queue at MAX_PENDING, and resumes processing once Redis returns.
+#
+# This test runs its own redis-server subprocess on a non-default port
+# so it can stop/start Redis at will without disturbing the CI service
+# container or the default 6379 instance used by other tests.
+
+import json
+import os
+import socket
+import subprocess
+import time
+import unittest
+
+import redis
+
+
+DAEMON_PATH = './tlopostats'
+DATABASE = 'tlopo_stats_resilience'
+REDIS_PORT = 6380
+RPC_PORT = 8964
+
+
+class TestRedisResilience(unittest.TestCase):
+    def setUp(self):
+        self.redis_proc = None
+        self.daemon_proc = None
+        self._start_redis()
+        self.client = redis.Redis(port=REDIS_PORT)
+        self._reset_db()
+        self._start_daemon()
+        # Configure a collector so events have somewhere to land.
+        self._rpc('add_incremental', name='kills', event='ENEMY_KILLED')
+
+    def tearDown(self):
+        if self.daemon_proc:
+            self.daemon_proc.kill()
+            self.daemon_proc.wait()
+        if self.redis_proc:
+            self.redis_proc.terminate()
+            # subprocess.TimeoutExpired doesn't exist in Py2.7 (which the
+            # Alpine 3.8 CI image still uses). Poll for exit instead so
+            # this works on both runtimes.
+            for _ in range(50):
+                if self.redis_proc.poll() is not None:
+                    break
+                time.sleep(0.1)
+            else:
+                self.redis_proc.kill()
+
+    def _start_redis(self):
+        # --save '' disables RDB snapshotting so the subprocess starts
+        # clean every run and a stop+start can't be confused by an
+        # auto-loaded dump.
+        self.redis_proc = subprocess.Popen(
+            ['redis-server', '--port', str(REDIS_PORT), '--save', '',
+             '--appendonly', 'no', '--daemonize', 'no'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # Wait until it accepts connections.
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                redis.Redis(port=REDIS_PORT).ping()
+                return
+            except redis.ConnectionError:
+                time.sleep(0.1)
+        raise RuntimeError('redis-server failed to start on port %d' % REDIS_PORT)
+
+    def _stop_redis(self):
+        if self.redis_proc and self.redis_proc.poll() is None:
+            self.redis_proc.terminate()
+            # Same Py2 compat note as in tearDown.
+            for _ in range(50):
+                if self.redis_proc.poll() is not None:
+                    break
+                time.sleep(0.1)
+            else:
+                self.redis_proc.kill()
+        self.redis_proc = None
+
+    def _start_daemon(self):
+        self.daemon_proc = subprocess.Popen(
+            [DAEMON_PATH, '--redis-db', '127.0.0.1', str(REDIS_PORT), DATABASE],
+            stderr=subprocess.PIPE)
+        time.sleep(1.0)
+
+    def _reset_db(self):
+        for key in self.client.keys(DATABASE + ':*'):
+            self.client.delete(key)
+
+    def _rpc(self, method, **kwargs):
+        kwargs['method'] = method
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(('127.0.0.1', RPC_PORT))
+        sock.send((json.dumps(kwargs) + '\n').encode())
+        return json.loads(sock.recv(1024))
+
+    def _send_event(self, name, doIds, value):
+        data = json.dumps({'event': name, 'doIds': doIds, 'value': value})
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(data.encode(), ('127.0.0.1', 8963))
+
+    def _events_in_queue(self):
+        return self.client.llen(DATABASE + ':events')
+
+    def test_daemon_survives_redis_outage_and_drains(self):
+        # Pre-outage: a few events land normally.
+        for _ in range(5):
+            self._send_event('ENEMY_KILLED', [1234], 1)
+        time.sleep(2)
+        pre_outage = self._events_in_queue()
+        self.assertGreater(pre_outage, 0)
+
+        # Kill Redis. The daemon's in-flight callbacks now start
+        # retrying on exponential backoff (1s -> 60s).
+        self._stop_redis()
+        time.sleep(2)
+
+        # Daemon must still be alive (the regression: it used to exit(1)
+        # after the third failed reconnect).
+        self.assertIsNone(self.daemon_proc.poll(),
+                          'daemon exited during Redis outage')
+
+        # Bring Redis back on the same port.
+        self._start_redis()
+        self.client = redis.Redis(port=REDIS_PORT)
+
+        # Send fresh events. They should flow through the freshly
+        # reconnected daemon. Allow up to one full backoff window for
+        # the daemon to notice Redis is back.
+        deadline = time.time() + 65
+        new_event_landed = False
+        while time.time() < deadline:
+            self._send_event('ENEMY_KILLED', [9999], 1)
+            time.sleep(2)
+            if self._events_in_queue() > 0:
+                new_event_landed = True
+                break
+        self.assertTrue(new_event_landed,
+                        'daemon never resumed sending events to Redis')
+
+    def test_daemon_stays_alive_through_long_outage(self):
+        # The old behaviour bailed out at ~3 retries. Confirm the daemon
+        # is still up after a long enough wait to exhaust the legacy
+        # retry budget several times over.
+        self._stop_redis()
+        time.sleep(20)
+        self.assertIsNone(self.daemon_proc.poll(),
+                          'daemon exited during long Redis outage')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #11.

`attempt_reconnect_or_abort` retries 3x and then calls `exit(1)`, silently dropping every event whose callback was waiting on `RPUSH`/`ZINCRBY`/`ZADD`. A brief Redis blip during a busy event takes the daemon down with no warning, and the data loss is invisible until someone notices leaderboards stopped updating.

Dropped the `exit(1)`: it retries forever now on exponential backoff (1s up to a 60s cap), with a bounded in-memory pending-command queue (capped at `MAX_PENDING = 10000`, anything past that is dropped with a `cerr` warning rather than growing unbounded). The synchronous sleep on the single-threaded io_service serialises the retries so there's no reconnect storm, and on reconnect the backoff resets and the queued callbacks drain.

Tested with `test/test_redis_resilience.py`, which spins up its own `redis-server` on port 6380 so it can stop and start Redis independently of CI, and confirms the daemon survives a 20s outage (well past the old three-retry budget) and events flow again once Redis is back. A manual run against the Test-Server Memurai would be a nice extra but CI covers the behavior.
